### PR TITLE
Make alienfile compatible with Perl 5.10

### DIFF
--- a/alienfile
+++ b/alienfile
@@ -304,11 +304,11 @@ sub update_pkg_conf_path {
     say 'Modifying drive paths in PKG_CONFIG_PATH';
     say $ENV{PKG_CONFIG_PATH};
     #  msys-ificate drive paths
-    @PKG_CONFIG_PATH = map {s{^([a-z]):}{/$1}ri} @PKG_CONFIG_PATH;
+    @PKG_CONFIG_PATH = map {my $r=$_; $r=~s{^([a-z]):}{/$1}i; $r} @PKG_CONFIG_PATH;
     #  make sure we get the dynamic libcurl
     #  (although the proj configure script does not currently use it)
     @PKG_CONFIG_PATH
-      = map {s{Alien-curl[/\\]lib[/\\]pkgconfig}{Alien-curl/dynamic/pkgconfig}ri}
+      = map {my $r=$_; $r=~s{Alien-curl[/\\]lib[/\\]pkgconfig}{Alien-curl/dynamic/pkgconfig}i; $r}
         @PKG_CONFIG_PATH;
     $ENV{PKG_CONFIG_PATH} = join ':', @PKG_CONFIG_PATH;
     say $ENV{PKG_CONFIG_PATH};


### PR DESCRIPTION
I've just changed PDL::GIS::Proj over (on a branch) to using Alien::proj. It doesn't work on 5.10 due to some 5.14 syntax (`s///r`). This replaces that, which is needed to be merged and released before I can complete PDL's changeover as I don't want to increase the minimum Perl version.