### PR TITLE
Add note that C++ is required

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -26,6 +26,7 @@ my %WriteMakefileArgs = (
     "VERSION_FROM" => "lib/Alien/proj.pm",
     "CONFIGURE_REQUIRES" => {
         %common_reqs,
+        "ExtUtils::CBuilder" => "0.27",  # have_cplusplus
         "PkgConfig"  => 0,
     },
     "BUILD_REQUIRES" => {

--- a/alienfile
+++ b/alienfile
@@ -15,6 +15,10 @@ my $on_automated_rig
   || $ENV{CI};
 
 
+use ExtUtils::CBuilder;
+say "Error: PROJ requires a C++ compiler, which was not found on this system."
+    unless eval { ExtUtils::CBuilder->new->have_cplusplus };
+
 use Cwd;
 my $base_dir = getcwd();
 

--- a/lib/Alien/proj.pm
+++ b/lib/Alien/proj.pm
@@ -146,6 +146,8 @@ The Proj library can be accessed from Perl code via the L<Geo::Proj4> package.
 Note: As of version 1.07, share installs will look for libtiff and curl support for proj 7
 and include them if they are found, except that curl will not be added if it is statically compiled.
 
+The PROJ library requires a C++ compiler.
+
 
 =head1 User defined config args
 


### PR DESCRIPTION
I tried installing Alien::proj on a system that didn’t have a C++ compiler. Not being aware of the compiler being missing, I spent some time looking through your recent changes regarding cmake, searching for a problem that didn’t exist.

I feel like a note in the documentation would be useful.

This PR also adds a check for C++ that prints a message right at the start if no suitable compiler can be found. Not sure how helpful this will turn out to be, but I suppose it can’t hurt?