### PR TITLE
plugin 'Build::SearchDep': Only search share type aliens 

### DIFF
--- a/alienfile
+++ b/alienfile
@@ -34,7 +34,7 @@ $have{$lib} = eval "require $lib";
 if ($have{$lib}) {
     #say 'Adding libtiff dependency';
     unshift @PATH, $lib->bin_dir;
-    push @dep_aliens, $lib;
+    push @dep_aliens, $lib if $lib->install_type eq 'share';
     my $p;
     if ($on_windows && $lib->install_type eq 'system') {
       #  dirty hack for strawberry perl

--- a/alienfile
+++ b/alienfile
@@ -51,12 +51,6 @@ if ($have{$lib}) {
 
 say "Alien::sqlite has sqlite version " . Alien::sqlite->version;
 
-plugin 'Build::SearchDep' => (
-  aliens   => [ @dep_aliens ],
-  public_I => 1,
-  public_l => 1,
-);
-
 my $min_target_version = '7.1';
 
 plugin 'PkgConfig' => (
@@ -106,6 +100,12 @@ share {
   #        . 'Alien::libtiff'->libs;
   #  say "libtiff libs: $ENV{TIFF_LIBS}";
   #}
+
+  plugin 'Build::SearchDep' => (
+    aliens   => [ @dep_aliens ],
+    public_I => 1,
+    public_l => 1,
+  );
 
 
   if ($on_windows) {


### PR DESCRIPTION
Otherwise the libs include system paths before the share aliens.  If there are system installs of these libs then they are linked first, potentially using out of date libraries and causing build problems.